### PR TITLE
Remove the Google linter, and add a typescript linter for eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+./src/reportWebVitals.ts
+./.eslintrc.cjs

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    '@typescript-eslint',
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  'extends': 'google',
-  'rules': {
-    // Additional, per-project rules...
-  },
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@types/eslint": "^8.4.3",
+        "@typescript-eslint/parser": "^5.27.1",
         "eslint": "^8.17.0",
         "eslint-config-google": "^0.14.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@types/eslint": "^8.4.3",
+    "@typescript-eslint/parser": "^5.27.1",
     "eslint": "^8.17.0",
     "eslint-config-google": "^0.14.0"
   }


### PR DESCRIPTION
The Google linter wasn't behaving well with TypeScript, so I traded it out for Typescript linter for ESLint. Added filters to the ESLint ignore file to cover the rest of the cases.